### PR TITLE
Fix parameters of show-versioninfo

### DIFF
--- a/.github/workflows/codetest-workflow.yml
+++ b/.github/workflows/codetest-workflow.yml
@@ -34,7 +34,7 @@ jobs:
           # Architecture of the Julia binaries. Defaults to x64.
           arch: x64 # optional, default is x64
           # Display InteractiveUtils.versioninfo() after installing
-          show-versioninfo: ture # optional, default is false
+          show-versioninfo: true # optional, default is false
 
       - name: Build docs by make docs command
         run: make docs

--- a/.github/workflows/documentation-workflow.yml
+++ b/.github/workflows/documentation-workflow.yml
@@ -34,7 +34,7 @@ jobs:
           # Architecture of the Julia binaries. Defaults to x64.
           arch: x64 # optional, default is x64
           # Display InteractiveUtils.versioninfo() after installing
-          show-versioninfo: ture # optional, default is false
+          show-versioninfo: true # optional, default is false
 
       - name: Build docs by make docs command
         run: make docs


### PR DESCRIPTION
This is a patch to fix `show-versioninfo` parameters used when installing julia on github-actions.
The build error in #51 will be resolved by this patch.
